### PR TITLE
WIP: support for export files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ version_info.txt
 .tmp
 .build
 _build
+cmake-build-*

--- a/share/files/mainmenu.ini
+++ b/share/files/mainmenu.ini
@@ -12,15 +12,16 @@
 1=actionNewNoteByTemplate
 2=-
 3=actionImportFile
-4=-
-5=actionSaveAsPDF
-6=actionSaveAsHtml
-7=actionSaveAsMarkdown
-8=-
-9=actionClose
-10=actionLogout
-11=-
-12=actionExit
+4=actionExportFile
+5=-
+6=actionSaveAsPDF
+7=actionSaveAsHtml
+8=actionSaveAsMarkdown
+9=-
+10=actionClose
+11=actionLogout
+12=-
+13=actionExit
 
 [&Edit]
 0=actionEditingUndo

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -204,6 +204,8 @@ set(wiznote_SOURCES
     WizUpgrade.cpp
     WizButton.cpp
     WizFileImporter.cpp
+    WizFileExporter.cpp
+    WizFileExportDialog.cpp
     WizProgressDialog.cpp
     WizDocumentSelectionView.cpp
     WizDocumentTransitionView.cpp
@@ -385,6 +387,8 @@ set(wiznote_HEADERS
     WizDocumentTransitionView.h
     WizButton.h
     WizFileImporter.h
+    WizFileExporter.h
+    WizFileExportDialog.h
     WizProgressDialog.h
     WizDocumentSelectionView.h
     WizUserVerifyDialog.h

--- a/src/WizActions.cpp
+++ b/src/WizActions.cpp
@@ -76,6 +76,7 @@ WIZACTION* WizActions::actionsData()
         {WIZACTION_GLOBAL_SAVE_AS_HTML,         QObject::tr("Save as Html..."),             "",                                     QKeySequence()},
         {WIZACTION_GLOBAL_SAVE_AS_MARKDOWN,     QObject::tr("Save as Markdown..."),         "",                                     QKeySequence()},
         {WIZACTION_GLOBAL_IMPORT_FILE,          QObject::tr("Import Files..."),             "",                                     QKeySequence()},
+        {WIZACTION_GLOBAL_EXPORT_FILE,          QObject::tr("Export Files..."),             "",                                     QKeySequence()},
         {WIZACTION_GLOBAL_PRINT_MARGIN,         QObject::tr("PDF Page Margins..."),         "",                                     QKeySequence()},
         //{WIZACTION_GLOBAL_VIEW_MESSAGES,      QObject::tr("View messages"),               "",                                     QKeySequence()},
         {WIZACTION_GLOBAL_GOBACK,               QObject::tr("Back"),                        "",                                     QKeySequence()},

--- a/src/WizActions.h
+++ b/src/WizActions.h
@@ -21,6 +21,7 @@ class QShortcut;
 #define WIZACTION_GLOBAL_SAVE_AS_HTML        "actionSaveAsHtml"
 #define WIZACTION_GLOBAL_SAVE_AS_MARKDOWN    "actionSaveAsMarkdown"
 #define WIZACTION_GLOBAL_IMPORT_FILE            "actionImportFile"
+#define WIZACTION_GLOBAL_EXPORT_FILE            "actionExportFile"
 #define WIZACTION_GLOBAL_PRINT_MARGIN        "actionPrintMargin"
 #define WIZACTION_GLOBAL_TOGGLE_CATEGORY    "actionViewToggleCategory"
 #define WIZACTION_GLOBAL_SHOW_SUB_FOLDER_DOCUMENTS      "actionViewShowSubFolderDocuments"

--- a/src/WizFileExportDialog.cpp
+++ b/src/WizFileExportDialog.cpp
@@ -30,10 +30,15 @@
 
 class BaseItem : public QTreeWidgetItem
 {
+
 public:
-    BaseItem(WizExplorerApp& app, QString strName, QString kbGUID): m_name(strName), m_kbGUID(kbGUID) {
+    BaseItem(WizExplorerApp& app, QString strName, QString kbGUID)
+        : m_name(strName)
+        , m_kbGUID(kbGUID)
+    {
         setText(0, strName);
     }
+
     QString name() const { return m_name; }
     QString kbGUID() const { return m_kbGUID; }
     virtual bool isFolder() const { return false; }
@@ -45,26 +50,44 @@ protected:
 
 class FolderItem : public BaseItem
 {
+
 public:
-    FolderItem(WizExplorerApp& app, QString strName, QString kbGUID): BaseItem(app, strName, kbGUID) {
-        QString iconKey = "category_folder";
-        QIcon icon = WizLoadSkinIcon(app.userSettings().skin(), iconKey);
+    FolderItem(WizExplorerApp& app, QString strName, QString kbGUID)
+        : BaseItem(app, strName, kbGUID)
+    {
+
+        auto name = WizDatabase::getLocationDisplayName(strName);
+        setText(0, name);
+
+        QIcon icon;
+        if (::WizIsPredefinedLocation(strName) && strName == "/My Journals/") {
+            icon = WizLoadSkinIcon(app.userSettings().skin(), "category_folder_diary");
+        } else {
+            icon  = WizLoadSkinIcon(app.userSettings().skin(), "category_folder");
+        }
+
         setIcon(0, icon);
     }
+
     bool isFolder() const override { return true; }
+    QString location() const { return m_name; }
 };
 
 class NoteItem : public BaseItem
 {
+
 public:
     NoteItem(WizExplorerApp& app, QString strName, QString kbGUID, QString docGUID, QString docType)
-    : BaseItem(app, strName, kbGUID), m_docGUID(docGUID), m_docType(docType) {
+        : BaseItem(app, strName, kbGUID)
+        , m_docGUID(docGUID)
+        , m_docType(docType)
+    {
+        // TODO: display icon for encrypted notes
         QString iconKey = "document_badge";
         QIcon icon = WizLoadSkinIcon(app.userSettings().skin(), iconKey);
         setIcon(0, icon);
-        setText(1, docGUID);
-        setText(2, docType);
     }
+
     bool isFolder() const override { return false; }
     QString docGUID() const { return m_docGUID; }
     QString docType() const { return m_docType; }
@@ -87,8 +110,7 @@ WizFileExportDialog::WizFileExportDialog(WizExplorerApp &app, QWidget *parent)
 
     m_treeWidget = new QTreeWidget(this);
     m_treeWidget->header()->setSectionResizeMode(QHeaderView::ResizeToContents);
-    // m_treeWidget->setHeaderHidden(true);
-    m_treeWidget->setHeaderLabels({"Name", "GUID", "Type"});
+    m_treeWidget->setHeaderHidden(true);
     connect(m_treeWidget, &QTreeWidget::itemChanged, this, &WizFileExportDialog::handleItemChanged);
     connect(m_treeWidget, &QTreeWidget::itemDoubleClicked, this, &WizFileExportDialog::handleItemDoubleClicked);
     layout->addWidget(m_treeWidget);

--- a/src/WizFileExportDialog.cpp
+++ b/src/WizFileExportDialog.cpp
@@ -1,0 +1,289 @@
+//
+// Created by pikachu on 2/16/2022.
+//
+
+#include "WizFileExportDialog.h"
+#include <QDebug>
+#include <QTreeWidget>
+#include <QTreeWidgetItem>
+#include <QVBoxLayout>
+#include <QHBoxLayout>
+#include <QLabel>
+#include <QPushButton>
+#include <QMessageBox>
+#include <QTextDocument>
+#include <QFile>
+#include <QDir>
+#include <QFileDialog>
+#include <QDesktopServices>
+#include "WizDef.h"
+#include "share/WizSettings.h"
+#include "share/WizMisc.h"
+#include "database/WizDatabaseManager.h"
+#include "database/WizDatabase.h"
+class BaseItem : public QTreeWidgetItem {
+public:
+    BaseItem(WizExplorerApp& app, QString strName, QString kbGUID): m_name(strName), m_kbGUID(kbGUID) {
+        setText(0, strName);
+    }
+    QString name() const { return m_name; }
+    QString kbGUID() const { return m_kbGUID; }
+    virtual bool isFolder() const { return false; }
+protected:
+    QString m_name;
+    QString m_kbGUID;
+};
+class FolderItem : public BaseItem {
+public:
+    FolderItem(WizExplorerApp& app, QString strName, QString kbGUID): BaseItem(app, strName, kbGUID) {
+        QString iconKey = "category_folders";
+        QIcon icon = WizLoadSkinIcon(app.userSettings().skin(), iconKey);
+        setIcon(0, icon);
+    }
+    bool isFolder() const override { return true; }
+private:
+};
+class NoteItem : public BaseItem {
+public:
+    NoteItem(WizExplorerApp& app, QString strName, QString kbGUID, QString docGUID, QString docType)
+    : BaseItem(app, strName, kbGUID), m_docGUID(docGUID), m_docType(docType) {
+        QString iconKey = "document_badge";
+        QIcon icon = WizLoadSkinIcon(app.userSettings().skin(), iconKey);
+        setIcon(0, icon);
+        setText(1, docGUID);
+        setText(2, docType);
+    }
+    bool isFolder() const override { return false; }
+    QString docGUID() const { return m_docGUID; }
+    QString docType() const { return m_docType; }
+private:
+    QString m_docGUID;
+    QString m_docType;
+};
+WizFileExportDialog::WizFileExportDialog(WizExplorerApp &app, QWidget *parent)
+: QDialog(parent)
+, m_isUpdateItemStatus(false)
+, m_app(app)
+, m_dbMgr(app.databaseManager()) {
+    this->resize(800, 600);
+    auto layout = new QVBoxLayout(this);
+    setLayout(layout);
+    layout->addWidget(new QLabel(tr("Choose notes")));
+    m_treeWidget = new QTreeWidget(this);
+    // m_treeWidget->setHeaderHidden(true);
+    m_treeWidget->setHeaderLabels({"Name", "GUID", "Type"});
+    connect(m_treeWidget, &QTreeWidget::itemChanged, this, &WizFileExportDialog::handleItemChanged);
+    connect(m_treeWidget, &QTreeWidget::itemDoubleClicked, this, &WizFileExportDialog::handleItemDoubleClicked);
+    layout->addWidget(m_treeWidget);
+    auto hbox = new QHBoxLayout();
+    hbox->addStretch(1);
+    auto confirmBtn = new QPushButton(tr("Confirm"));
+    auto cancelBtn = new QPushButton(tr("Cancel"));
+    hbox->addWidget(confirmBtn);
+    hbox->addWidget(cancelBtn);
+    layout->addLayout(hbox);
+
+    connect(confirmBtn, &QPushButton::clicked, this, &WizFileExportDialog::handleExportFile);
+    connect(cancelBtn, &QPushButton::clicked, this, &QDialog::reject);
+    
+
+    initFolders();
+}
+
+void WizFileExportDialog::initFolders() {
+    auto pAllFoldersItem = new FolderItem(m_app, tr("Personal Notes"), m_dbMgr.db().kbGUID());
+    pAllFoldersItem->setCheckState(0, Qt::Unchecked);
+    m_treeWidget->addTopLevelItem(pAllFoldersItem);
+    m_rootItem = pAllFoldersItem;
+
+    CWizStdStringArray arrayAllLocation;
+    m_dbMgr.db().getAllLocations(arrayAllLocation);
+
+    // folder cache
+    CWizStdStringArray arrayExtLocation;
+    m_dbMgr.db().getExtraFolder(arrayExtLocation);
+
+    if (!arrayExtLocation.empty()) {
+        for (CWizStdStringArray::const_iterator it = arrayExtLocation.begin();
+             it != arrayExtLocation.end();
+             it++) {
+            if (-1 == ::WizFindInArray(arrayAllLocation, *it)) {
+                arrayAllLocation.push_back(*it);
+            }
+        }
+    }
+
+    if (arrayAllLocation.empty()) {
+        arrayAllLocation.push_back(m_dbMgr.db().getDefaultNoteLocation());
+    }
+
+    initFolders(pAllFoldersItem, "", arrayAllLocation);
+
+    pAllFoldersItem->setExpanded(true);
+    pAllFoldersItem->sortChildren(0, Qt::AscendingOrder);
+}
+
+void WizFileExportDialog::initFolders(QTreeWidgetItem *pParent, const QString &strParentLocation,
+                                      const CWizStdStringArray &arrayAllLocation) {
+    CWizStdStringArray arrayLocation;
+    WizDatabase::getChildLocations(arrayAllLocation, strParentLocation, arrayLocation);
+
+    CWizStdStringArray::const_iterator it;
+    for (const auto& strLocation: arrayLocation) {
+
+        if (m_dbMgr.db().isInDeletedItems(strLocation))
+            continue;
+
+        auto pFolderItem = new FolderItem(m_app, strLocation, m_dbMgr.db().kbGUID());
+        pFolderItem->setCheckState(0, Qt::Unchecked);
+        pParent->addChild(pFolderItem);
+
+        initFolders(pFolderItem, strLocation, arrayAllLocation);
+    }
+    CWizDocumentDataArray arrayDocument;
+    m_dbMgr.db().getDocumentsByLocation(strParentLocation, arrayDocument);
+    for(const auto& doc: arrayDocument) {
+        if (!WizIsMarkdownNote(doc)) continue;
+        auto pNoteItem = new NoteItem(m_app, doc.strTitle, m_dbMgr.db().kbGUID(), doc.strGUID, doc.strType);
+        pNoteItem->setCheckState(0, Qt::Unchecked);
+        pParent->addChild(pNoteItem);
+    }
+
+}
+
+void WizFileExportDialog::handleItemChanged(QTreeWidgetItem *item, int column) {
+    if (m_isUpdateItemStatus) return;
+    m_isUpdateItemStatus = true;
+    updateChildItemStatus(item);
+    updateParentItemStatus(item);
+    m_isUpdateItemStatus = false;
+}
+
+void WizFileExportDialog::updateParentItemStatus(QTreeWidgetItem* item)
+{
+    auto parent = item->parent();
+    if (Q_NULLPTR == parent)
+    {
+        return;
+    }
+
+    parent->setCheckState(0, item->checkState(0));
+    int nCount = parent->childCount();
+    for (int nIndex = 0; nIndex < nCount; ++nIndex)
+    {
+        auto child = parent->child(nIndex);
+        if (child->checkState(0) != parent->checkState(0))
+        {
+            parent->setCheckState(0, Qt::PartiallyChecked);
+            break;
+        }
+    }
+
+    updateParentItemStatus(parent);
+}
+
+void WizFileExportDialog::updateChildItemStatus(QTreeWidgetItem* item)
+{
+    int nCount = item->childCount();
+    for (int nIndex = 0; nIndex < nCount; ++nIndex)
+    {
+        auto child = item->child(nIndex);
+        child->setCheckState(0, item->checkState(0));
+        if (child->childCount() > 0)
+        {
+            updateChildItemStatus(child);
+        }
+    }
+}
+
+void WizFileExportDialog::handleItemDoubleClicked(QTreeWidgetItem *item, int column) {
+    auto _item = static_cast<BaseItem*>(item);
+    if (_item->isFolder()) {
+        return;
+    }
+    auto state = item->checkState(0);
+    if (state == Qt::Unchecked) {
+        item->setCheckState(0, Qt::Checked);
+    } else if (state == Qt::Checked) {
+        item->setCheckState(0, Qt::Unchecked);
+    }
+}
+
+void WizFileExportDialog::handleExportFile() {
+    if (m_rootItem->checkState(0) == Qt::Unchecked) {
+        QMessageBox::warning(nullptr, tr("Export Error"), tr("No selected notes"));
+        return;
+    }
+    m_exportRootPath = QFileDialog::getExistingDirectory();
+    if (m_exportRootPath.isEmpty()) return;
+    qDebug() << "export root path:" << m_exportRootPath;
+    exportFolder(m_rootItem);
+    QMessageBox::information(nullptr, tr("Export Success"), tr("All notes selected exported"));
+    QDesktopServices::openUrl(QUrl(m_exportRootPath));
+}
+
+void WizFileExportDialog::exportFolder(QTreeWidgetItem *item) {
+    if (item->checkState(0) == Qt::Unchecked) return;
+    int nCount = item->childCount();
+    for (int nIndex = 0; nIndex < nCount; ++nIndex)
+    {
+        auto child = static_cast<BaseItem*>(item->child(nIndex));
+        if (child->isFolder()) {
+            exportFolder(child);
+        } else {
+            exportNote(child);
+        }
+    }
+}
+void WizFileExportDialog::exportNote(QTreeWidgetItem *item) {
+    auto parentItem = static_cast<FolderItem*>(item->parent());
+    if (!parentItem) return;
+    QString path = m_exportRootPath + "/" + parentItem->name();
+    auto noteItem = static_cast<NoteItem*>(item);
+    QString filename = noteItem->name();
+    qDebug() << "export " << noteItem->name();
+    
+    WizDatabase& db = m_dbMgr.db(noteItem->kbGUID());
+    WIZDOCUMENTDATA data;
+    if (!db.documentFromGuid(noteItem->docGUID(), data))
+    {
+        return;
+    }
+    if (!WizMakeSureDocumentExistAndBlockWidthDialog(db, data)) {
+        return;
+    }
+    // TODO: handle cipher, not supported now
+    //
+    QString strHtmlFile;
+    if (db.documentToTempHtmlFile(data, strHtmlFile))
+    {
+        qDebug() << "html:" << strHtmlFile;
+        QFile file(strHtmlFile);
+        if (!file.open(QIODevice::ReadOnly)) {
+            qDebug() << "open html file fail:" << strHtmlFile;
+            return;
+        }
+        QString strHtml = file.readAll();
+        file.close();
+        QTextDocument doc;
+        doc.setHtml(strHtml);
+        QString strText = doc.toPlainText();
+        strText = strText.replace("&nbsp", " ");
+        // write text to file
+        QString outputFilePath = path + "/" + filename;
+        qDebug() << "export to:" << outputFilePath;
+        QDir().mkpath(path);
+        if (!WizSaveUnicodeTextToUtf8File(outputFilePath, strText)) {
+            qDebug() << "export fail:" << noteItem->name();
+            return;
+        }
+        qDebug() << "export success:" << noteItem->name();
+         
+    }
+    else
+    {
+        qDebug() << "error doc to html";
+    }
+
+
+}

--- a/src/WizFileExportDialog.h
+++ b/src/WizFileExportDialog.h
@@ -7,15 +7,23 @@
 
 #include <QDialog>
 #include "share/WizQtHelper.h"
-class WizExplorerApp;
-class WizDatabaseManager;
+
 class QTreeWidget;
 class QTreeWidgetItem;
+class QProgressBar;
+class QLabel;
+
+class WizExplorerApp;
+class WizDatabaseManager;
 class BaseItem;
-class WizFileExportDialog : public QDialog {
-Q_OBJECT
+
+class WizFileExportDialog : public QDialog
+{
+    Q_OBJECT
+
 public:
     WizFileExportDialog(WizExplorerApp& app, QWidget *parent = nullptr);
+
 private:
     void initFolders();
     void initFolders(QTreeWidgetItem* pParent,
@@ -36,6 +44,8 @@ private:
     bool m_isUpdateItemStatus;
     QTreeWidgetItem* m_rootItem;
     QString m_exportRootPath;
+    QLabel* m_progressLabel;
+    QProgressBar* m_progress;
 };
 
 

--- a/src/WizFileExportDialog.h
+++ b/src/WizFileExportDialog.h
@@ -6,6 +6,8 @@
 #define WIZNOTEPLUS_WIZFILEEXPORTDIALOG_H
 
 #include <QDialog>
+#include <QList>
+
 #include "share/WizQtHelper.h"
 
 class QTreeWidget;
@@ -16,6 +18,8 @@ class QLabel;
 class WizExplorerApp;
 class WizDatabaseManager;
 class BaseItem;
+class NoteItem;
+class WizFileExporter;
 
 class WizFileExportDialog : public QDialog
 {
@@ -34,17 +38,17 @@ private:
     void handleItemDoubleClicked(QTreeWidgetItem *item, int column);
     void updateParentItemStatus(QTreeWidgetItem* item);
     void updateChildItemStatus(QTreeWidgetItem* item);
-    void exportFolder(QTreeWidgetItem* item);
-    void exportNote(QTreeWidgetItem* item);
+    QList<NoteItem*> findSelectedNotes(BaseItem* item);
 
 private:
     WizExplorerApp& m_app;
     WizDatabaseManager& m_dbMgr;
     QTreeWidget* m_treeWidget;
     bool m_isUpdateItemStatus;
-    QTreeWidgetItem* m_rootItem;
+    BaseItem* m_rootItem;
     QString m_exportRootPath;
     QProgressDialog* m_progress;
+    WizFileExporter* m_exporter;
 };
 
 

--- a/src/WizFileExportDialog.h
+++ b/src/WizFileExportDialog.h
@@ -1,0 +1,42 @@
+//
+// Created by pikachu on 2/16/2022.
+//
+
+#ifndef WIZNOTEPLUS_WIZFILEEXPORTDIALOG_H
+#define WIZNOTEPLUS_WIZFILEEXPORTDIALOG_H
+
+#include <QDialog>
+#include "share/WizQtHelper.h"
+class WizExplorerApp;
+class WizDatabaseManager;
+class QTreeWidget;
+class QTreeWidgetItem;
+class BaseItem;
+class WizFileExportDialog : public QDialog {
+Q_OBJECT
+public:
+    WizFileExportDialog(WizExplorerApp& app, QWidget *parent = nullptr);
+private:
+    void initFolders();
+    void initFolders(QTreeWidgetItem* pParent,
+                     const QString& strParentLocation,
+                     const CWizStdStringArray& arrayAllLocation);
+    void handleExportFile();
+    void handleItemChanged(QTreeWidgetItem *item, int column);
+    void handleItemDoubleClicked(QTreeWidgetItem *item, int column);
+    void updateParentItemStatus(QTreeWidgetItem* item);
+    void updateChildItemStatus(QTreeWidgetItem* item);
+    void exportFolder(QTreeWidgetItem* item);
+    void exportNote(QTreeWidgetItem* item);
+
+private:
+    WizExplorerApp& m_app;
+    WizDatabaseManager& m_dbMgr;
+    QTreeWidget* m_treeWidget;
+    bool m_isUpdateItemStatus;
+    QTreeWidgetItem* m_rootItem;
+    QString m_exportRootPath;
+};
+
+
+#endif //WIZNOTEPLUS_WIZFILEEXPORTDIALOG_H

--- a/src/WizFileExportDialog.h
+++ b/src/WizFileExportDialog.h
@@ -10,7 +10,7 @@
 
 class QTreeWidget;
 class QTreeWidgetItem;
-class QProgressBar;
+class QProgressDialog;
 class QLabel;
 
 class WizExplorerApp;
@@ -44,8 +44,7 @@ private:
     bool m_isUpdateItemStatus;
     QTreeWidgetItem* m_rootItem;
     QString m_exportRootPath;
-    QLabel* m_progressLabel;
-    QProgressBar* m_progress;
+    QProgressDialog* m_progress;
 };
 
 

--- a/src/WizFileExporter.cpp
+++ b/src/WizFileExporter.cpp
@@ -3,3 +3,92 @@
 //
 
 #include "WizFileExporter.h"
+
+#include <QFile>
+#include <QTextDocument>
+#include <QDir>
+#include <QDebug>
+
+#include "database/WizDatabase.h"
+#include "database/WizDatabaseManager.h"
+#include "share/WizMisc.h"
+
+WizFileExporter::WizFileExporter(WizDatabaseManager& dbMgr, QObject *parent)
+    : QObject(parent)
+    , m_dbMgr(dbMgr)
+{
+
+}
+
+bool WizFileExporter::exportNote(
+    const WIZDOCUMENTDATA &doc,
+    const QString &destFolder,
+    const ExportFormat format,
+    bool compress /*= false*/
+)
+{
+    WizDatabase& db = m_dbMgr.db(doc.strKbGUID);
+    if (!WizMakeSureDocumentExistAndBlockWidthEventloop(db, doc)) {
+        return false;
+    }
+
+    // TODO: handle cipher, not supported now
+
+    CString folder = doc.strTitle;
+    WizMakeValidFileNameNoPath(folder);
+    QDir docFolder(destFolder);
+    if (!docFolder.exists())
+        return false;
+    docFolder.mkpath(folder);
+    docFolder.cd(folder);
+
+    // TODO: write meta info to meta.json
+    // TODO: unzip index_files/ and index.html
+
+    QString strHtmlFile = docFolder.filePath("index.html");
+    if (db.documentToHtmlFile(doc, docFolder.absolutePath() + "/")) {
+        QFile file(strHtmlFile);
+        if (!file.open(QIODevice::ReadOnly)) {
+            return false;
+        }
+        QString strHtml = file.readAll();
+        file.close();
+
+        switch (format) {
+        case Markdown:
+        {
+            QString outputFilePath = docFolder.filePath("index.md");
+            if (!extractMarkdownToFile(strHtml, outputFilePath))
+                return false;
+            docFolder.remove("index.html");
+            break;
+        }
+        case HTML:
+        {
+
+        }
+        default:
+            break;
+        }
+
+    } else {
+        qWarning() << "Can't unzip document to " << docFolder.absolutePath();
+        return false;
+    }
+
+    return true;
+}
+
+bool WizFileExporter::extractMarkdownToFile(const QString &htmlContent, const QString &outputFile) {
+    QTextDocument doc;
+    doc.setHtml(htmlContent);
+    QString strText = doc.toPlainText();
+    strText = strText.replace("&nbsp", " ");
+
+    // write text to file
+    if (!WizSaveUnicodeTextToUtf8File(outputFile, strText)) {
+        return false;
+    }
+
+    return true;
+}

--- a/src/WizFileExporter.cpp
+++ b/src/WizFileExporter.cpp
@@ -1,0 +1,5 @@
+//
+// Created by pikachu on 2/16/2022.
+//
+
+#include "WizFileExporter.h"

--- a/src/WizFileExporter.h
+++ b/src/WizFileExporter.h
@@ -1,0 +1,18 @@
+//
+// Created by pikachu on 2/16/2022.
+//
+
+#ifndef WIZNOTEPLUS_WIZFILEEXPORTER_H
+#define WIZNOTEPLUS_WIZFILEEXPORTER_H
+
+#include <QObject>
+class WizDatabaseManager;
+class WizFileExporter : public QObject {
+Q_OBJECT
+public:
+    explicit WizFileExporter(WizDatabaseManager& dbMgr,QObject *parent = nullptr);
+private:
+};
+
+
+#endif //WIZNOTEPLUS_WIZFILEEXPORTER_H

--- a/src/WizFileExporter.h
+++ b/src/WizFileExporter.h
@@ -6,12 +6,31 @@
 #define WIZNOTEPLUS_WIZFILEEXPORTER_H
 
 #include <QObject>
+
 class WizDatabaseManager;
+class WIZDOCUMENTDATA;
+
 class WizFileExporter : public QObject {
-Q_OBJECT
+
+    Q_OBJECT
+
 public:
-    explicit WizFileExporter(WizDatabaseManager& dbMgr,QObject *parent = nullptr);
+    explicit WizFileExporter(WizDatabaseManager& dbMgr, QObject *parent = nullptr);
+
+    enum ExportFormat {
+        Markdown = 1 << 0,
+        HTML     = 1 << 1,
+        MHTML    = 1 << 2,
+        PDF      = 1 << 3
+    };
+
+    bool exportNote(const WIZDOCUMENTDATA &doc, const QString &destFolder, const ExportFormat format, bool compress = false);
+
 private:
+    bool extractMarkdownToFile(const QString &htmlContent, const QString &outputFile);
+
+private:
+    WizDatabaseManager& m_dbMgr;
 };
 
 

--- a/src/WizFileImporter.h
+++ b/src/WizFileImporter.h
@@ -8,8 +8,9 @@ struct WIZTAGDATA;
 class WizFileImporter : public QObject
 {
     Q_OBJECT
+
 public:
-    explicit WizFileImporter(WizDatabaseManager& dbMgr,QObject *parent = nullptr);
+    explicit WizFileImporter(WizDatabaseManager& dbMgr, QObject *parent = nullptr);
 
     void importFiles(const QStringList& strFiles, const QString& strTargetFolderLocation);
     void importFiles(const QStringList& strFiles, const QString& strKbGUID, const WIZTAGDATA& tag);
@@ -20,7 +21,7 @@ public:
     QString loadTextFileToHtml(const QString& strFileName);
     static QString loadTextFileToHtml(const QString& strFileName, const char *encoding);
     QString loadImageFileToHtml(const QString& strFileName);
-    //
+
 signals:
     void importFinished(bool ok, const QString& text, const QString& kbGuid);
     void importProgress(int total,int loaded);

--- a/src/WizMainWindow.cpp
+++ b/src/WizMainWindow.cpp
@@ -114,6 +114,8 @@
 #include "gui/documentviewer/WizEditorToolBar.h"
 #include "gui/documentviewer/WizSvgEditorDialog.h"
 
+#include "WizFileExportDialog.h"
+
 #define MAINWINDOW  "MainWindow"
 
 
@@ -3183,6 +3185,12 @@ void WizMainWindow::on_actionImportFile_triggered()
     WizGetAnalyzer().logAction("MenuBarImportFile");
 }
 
+void WizMainWindow::on_actionExportFile_triggered()
+{
+    WizFileExportDialog dialog(*this, this);
+    dialog.exec();
+    WizGetAnalyzer().logAction("MenuBarExportFile");
+}
 void WizMainWindow::on_actionPrintMargin_triggered()
 {
     WizPreferenceWindow preference(*this, this);

--- a/src/WizMainWindow.cpp
+++ b/src/WizMainWindow.cpp
@@ -3191,6 +3191,7 @@ void WizMainWindow::on_actionExportFile_triggered()
     dialog.exec();
     WizGetAnalyzer().logAction("MenuBarExportFile");
 }
+
 void WizMainWindow::on_actionPrintMargin_triggered()
 {
     WizPreferenceWindow preference(*this, this);

--- a/src/WizMainWindow.h
+++ b/src/WizMainWindow.h
@@ -291,6 +291,7 @@ public Q_SLOTS:
     void on_actionSaveAsHtml_triggered();
     void on_actionSaveAsMarkdown_triggered();
     void on_actionImportFile_triggered();
+    void on_actionExportFile_triggered();
     void on_actionPrintMargin_triggered();
 
     // menu editing

--- a/src/database/WizDatabase.cpp
+++ b/src/database/WizDatabase.cpp
@@ -3789,6 +3789,10 @@ CString WizDatabase::getObjectFileName(const WIZOBJECTDATA& data)
     }
 }
 
+/*!
+    Extract root parts of location strings in \a arrayAllLocation, and store
+    the unique set in \a arrayLocation.
+*/
 bool WizDatabase::getAllRootLocations(const CWizStdStringArray& arrayAllLocation, \
                                        CWizStdStringArray& arrayLocation)
 {
@@ -3804,25 +3808,30 @@ bool WizDatabase::getAllRootLocations(const CWizStdStringArray& arrayAllLocation
     return true;
 }
 
+/*!
+    Find direct child locations of \a strParentLocation from \a arrayAllLocation,
+    then store unique set in \a arrayLocation. If \a strParentLocation is empty,
+    then the unique root locations of \a arrayAllLocation is returned.
+ */
 bool WizDatabase::getChildLocations(const CWizStdStringArray& arrayAllLocation, \
-                                     const QString& strLocation, \
+                                     const QString& strParentLocation, \
                                      CWizStdStringArray& arrayLocation)
 {
-    if (strLocation.isEmpty())
+    if (strParentLocation.isEmpty())
         return getAllRootLocations(arrayAllLocation, arrayLocation);
 
     std::set<QString> setLocation;
 
     CWizStdStringArray::const_iterator it;
     for (it = arrayAllLocation.begin(); it != arrayAllLocation.end(); it++) {
-        const QString& str = *it;
+        const QString& location = *it;
 
-        if (str.length() > strLocation.length() && str.startsWith(strLocation))
+        if (location.length() > strParentLocation.length() && location.startsWith(strParentLocation))
         {
-            int index = str.indexOf('/', strLocation.length() + 1);
+            int index = location.indexOf('/', strParentLocation.length() + 1);
             if (index > 0)
             {
-                QString strChild = str.left(index + 1);
+                QString strChild = location.left(index + 1);
                 setLocation.insert(strChild);
             }
         }
@@ -4388,6 +4397,9 @@ bool WizDatabase::updateDocumentAbstract(const QString& strDocumentGUID)
     return ret;
 }
 
+/*!
+    Given a slash-separated path-like location string \a strLocation, return it's first part.
+*/
 CString WizDatabase::getRootLocation(const CString& strLocation)
 {
     //FIXME:容错处理，如果路径的结尾不是 '/'，则增加该结尾符号

--- a/src/database/WizDatabase.cpp
+++ b/src/database/WizDatabase.cpp
@@ -4611,6 +4611,10 @@ bool WizDatabase::QueryCertPassword()
     return false;
 }
 
+/*!
+    Unzip \a document to a temporary folder, and write path of "index.html" to
+    \a strFullPathFileName variable.
+*/
 bool WizDatabase::documentToTempHtmlFile(const WIZDOCUMENTDATA& document,
                                           QString& strFullPathFileName)
 {
@@ -4624,6 +4628,9 @@ bool WizDatabase::documentToTempHtmlFile(const WIZDOCUMENTDATA& document,
     return WizPathFileExists(strFullPathFileName);
 }
 
+/*!
+    Unzip \a document to a given folder of \a strPath.
+*/
 bool WizDatabase::documentToHtmlFile(const WIZDOCUMENTDATA& document,
                                           const QString& strPath)
 {


### PR DESCRIPTION

- add export files action
![image](https://user-images.githubusercontent.com/18223871/154270680-eab94673-a673-49bc-9a24-6d0d57138751.png)

- add export files dialog

![image](https://user-images.githubusercontent.com/18223871/154271046-8390d144-5354-4b4c-8318-05182c8c0b90.png)

export results
![image](https://user-images.githubusercontent.com/18223871/154271156-cafbb76b-c164-4889-94b8-15131488183e.png)



TODO:

- [ ] download note if not exits
- [ ] handle cipher
- [ ] export assets
- [ ] validate file name, currently same with note name in db
- [ ] UI/UX, multi-threading etc